### PR TITLE
Allow policies to be bound on gateway interfaces

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -20,3 +20,15 @@ jobs:
         run: pip install "tox<4.0"
       - name: Run Tox
         run: "tox -e py"
+  pep8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox pep8
+        run: "tox -e pep8"

--- a/neutron_fwaas/tests/unit/services/firewall/service_drivers/test_driver_api.py
+++ b/neutron_fwaas/tests/unit/services/firewall/service_drivers/test_driver_api.py
@@ -16,8 +16,12 @@
 import copy
 
 import mock
+from neutron.objects import router
 from neutron_lib.callbacks import events
+from neutron_lib import constants as nl_constants
 from neutron_lib import context
+from oslo_utils import uuidutils
+from webob.exc import HTTPClientError
 
 from neutron_fwaas.common import fwaas_constants as const
 from neutron_fwaas.tests.unit.services.firewall import test_fwaas_plugin_v2
@@ -196,7 +200,47 @@ class FireWallDriverDBMixinTestCase(test_fwaas_plugin_v2.
                                        self.driver_api,
                                        payload=self.m_payload)
 
-    # Test Firewall Rule
+    def test_add_router_external_port_to_fwg(self):
+        self.plugin.l3_plugin = mock.Mock()
+        with self.subnet() as subnet:
+            r = router.Router(self.ctx, id=uuidutils.generate_uuid(),
+                              project_id=subnet['subnet']['tenant_id'])
+            r.create()
+            with self.port(subnet=subnet, device_id=r.id, tenant_id=None,
+                           device_owner=nl_constants.DEVICE_OWNER_ROUTER_GW) as gwport, self.firewall_policy() as pol:
+                with mock.patch.object(self.plugin.l3_plugin, 'get_router',
+                                       return_value=dict(tenant_id=subnet['subnet']['tenant_id'])):
+                    with mock.patch.object(self.plugin.driver,
+                                           'is_supported_l3_port', return_value=True):
+                        fwg_kwargs = dict(ingress_firewall_policy_id=pol['firewall_policy']['id'],
+                                          ports=[gwport['port']['id']])
+
+                        with self.firewall_group(**fwg_kwargs) as fwg:
+                            self.assertIsNotNone(fwg)
+
+    def test_add_router_foreign_external_port_to_fwg(self):
+        tenant_id = uuidutils.generate_uuid()
+        self.plugin.l3_plugin = mock.Mock()
+
+        with self.subnet(tenant_id=tenant_id) as subnet:
+            r = router.Router(self.ctx, ids=uuidutils.generate_uuid(),
+                              project_id=subnet['subnet']['tenant_id'])
+            r.create()
+            with self.port(subnet=subnet, device_id=r.id, tenant_id=None,
+                           device_owner=nl_constants.DEVICE_OWNER_ROUTER_GW) as gwport, self.firewall_policy() as pol:
+                def call_ctx_mgr(method, *args, **kwargs):
+                    with method(*args, **kwargs):
+                        pass
+
+                with mock.patch.object(self.plugin.l3_plugin, 'get_router',
+                                       return_value=dict(tenant_id=subnet['subnet']['tenant_id'])):
+                    fwg_kwargs = dict(ingress_firewall_policy_id=pol['firewall_policy']['id'],
+                                      ports=[gwport['port']['id']],
+                                    tenant_id=uuidutils.generate_uuid())
+                    self.assertRaisesRegex(HTTPClientError, 'Operation cannot be performed as port .* '
+                                                            'is in an invalid project',
+                                           call_ctx_mgr, self.firewall_group, **fwg_kwargs)
+
     def test_create_firewall_rule(self):
 
         with mock.patch.object(self.firewall_db, 'create_firewall_rule',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py39,pep8,pylint
+envlist = py38,pep8,pylint
 minversion = 3.18.0
+ignore_basepython_conflict = True
 
 [testenv]
 basepython = {env:TOX_PYTHON:python3}
@@ -12,7 +13,6 @@ setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 deps = -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt}
        -r{toxinidir}/requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
        -r{toxinidir}/test-requirements.txt
 allowlist_externals =
   bash
@@ -171,6 +171,7 @@ ignore-path = .venv,.git,.tox,.tmp,*neutron_fwaas/locale*,*lib/python*,neutron_f
 # (W503 and W504 are incompatible and we need to choose one of them.
 #  Existing codes follows W503, so we disable W504.)
 ignore = E125,E126,E128,E129,E265,H404,H405,N530,N521,W504
+max-line-length = 120
 enable-extensions=H106,H203,H204,H205,H904
 show-source = true
 exclude = .venv,.git,.tox,dist,doc,*lib/python*,.tmp,*egg,build,tools,.ropeproject,rally-scenarios


### PR DESCRIPTION
The gateway interface is the external side of the router. As we want to
be able to identify traffic coming from that interface, we also need to be
able to bind policies on it.