### PR TITLE
[Caracal] Fix downstream tests

### DIFF
--- a/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
+++ b/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
@@ -345,15 +345,16 @@ class FirewallPluginV2TestCase(test_db_plugin.NeutronDbPluginV2TestCase):
                      'egress_firewall_policy_id': egress_firewall_policy_id,
                      'admin_state_up': admin_state_up}}
         ctx = kwargs.get('context', None)
+        # Without this, the tenant_id always is set to self._tenant_id
+        tenant_id = kwargs.get('tenant_id', self._tenant_id)
         if ctx is None or ctx.is_admin:
-            tenant_id = kwargs.get('tenant_id', self._tenant_id)
             data['firewall_group'].update({'tenant_id': tenant_id})
             data['firewall_group'].update({'project_id': tenant_id})
         if ports is not None:
             data['firewall_group'].update({'ports': ports})
 
         req = self.new_create_request('firewall_groups', data, fmt,
-                                      context=ctx, as_admin=as_admin)
+                                      context=ctx, as_admin=as_admin, tenant_id=tenant_id)
         res = req.get_response(self.ext_api)
         if expected_res_status:
             self.assertEqual(expected_res_status, res.status_int)


### PR DESCRIPTION
[Caracal] Fix downstream tests

 Allowing policies to be bound on gateway interfaces introduces some
 extra set of tests only existing in our FwaaS repo.

Since the new RBAC model is the new default for Authorization, the Neutron
classes supporting unit testing change.
Subports can not be created with set_context anymore. Also the Neutron classes mocking
requests provide a default tenant_id for Neutron
objects like subports, ports, firewall groups if not set explicitly.

The last behaviour breaks the test test_add_router_external_port_to_fwg.
Giving the tenant_id as a parameter makes sure no
FirewallGroupPortInvalidProject is raised, as the router tenant_id is equal
to tenant_id passed allong with the create firewall group request.
 If not set, default testing tenant_id would be compared with the router tenant_id.