### PR TITLE
Firewall group associated with ports is not allowed to be deleted

### DIFF
--- a/neutron_fwaas/services/firewall/fwaas_plugin_v2.py
+++ b/neutron_fwaas/services/firewall/fwaas_plugin_v2.py
@@ -349,7 +349,7 @@ class FirewallPluginV2(Firewallv2PluginBase):
         except f_exc.FirewallGroupNotFound:
             return
 
-        if fwg['status'] == nl_constants.ACTIVE:
+        if fwg['ports']:
             raise f_exc.FirewallGroupInUse(firewall_id=id)
 
         self.driver.delete_firewall_group(context, id)

--- a/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
+++ b/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
@@ -374,6 +374,22 @@ class FirewallPluginV2TestCase(test_db_plugin.NeutronDbPluginV2TestCase):
         firewall_group = self.deserialize(fmt or self.fmt, res)
         yield firewall_group
         if do_delete:
+            self.plugin.driver.firewall_db.update_firewall_group_status(
+                context.get_admin_context(),
+                firewall_group['firewall_group']['id'],
+                nl_constants.ACTIVE)
+            data = {
+                'firewall_group': {
+                    'ports': [],
+                },
+            }
+            req = self.new_update_request(
+                'firewall_groups',
+                data,
+                firewall_group['firewall_group']['id'],
+                as_admin=True,
+            )
+            req.get_response(self.ext_api)
             self._delete('firewall_groups',
                          firewall_group['firewall_group']['id'])
 

--- a/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
+++ b/neutron_fwaas/tests/unit/services/firewall/test_fwaas_plugin_v2.py
@@ -386,8 +386,7 @@ class FirewallPluginV2TestCase(test_db_plugin.NeutronDbPluginV2TestCase):
             req = self.new_update_request(
                 'firewall_groups',
                 data,
-                firewall_group['firewall_group']['id'],
-                as_admin=True,
+                firewall_group['firewall_group']['id']
             )
             req.get_response(self.ext_api)
             self._delete('firewall_groups',


### PR DESCRIPTION
Currently, we determine that the firewall group is in use based on its ACTIVE status. But the firewall group may have just updated the port and is currently PENDING_UPDATE status, deletion should not be allowed at this time.
This patch changes the judgment method for deleting firewall groups, no longer based on their status. But like other neutron resources, based on whether or not they are associated.

Closes-Bug: #2018967
Depends-On: https://review.opendev.org/c/openstack/neutron-tempest-plugin/+/883826

Change-Id: Ib7ab0daf9f6de45125ffc9408f865fc0964ff339