### PR TITLE
Use reader context for DB queries

### DIFF
--- a/neutron_fwaas/db/firewall/v2/firewall_db_v2.py
+++ b/neutron_fwaas/db/firewall/v2/firewall_db_v2.py
@@ -206,18 +206,21 @@ class FirewallPluginDb(object):
             result_filters=_list_firewall_policies_result_filter_hook)
         return super(FirewallPluginDb, cls).__new__(cls, *args, **kwargs)
 
+    @db_api.CONTEXT_READER
     def _get_firewall_group(self, context, id):
         try:
             return model_query.get_by_id(context, FirewallGroup, id)
         except exc.NoResultFound:
             raise f_exc.FirewallGroupNotFound(firewall_id=id)
 
+    @db_api.CONTEXT_READER
     def _get_firewall_policy(self, context, id):
         try:
             return model_query.get_by_id(context, FirewallPolicy, id)
         except exc.NoResultFound:
             raise f_exc.FirewallPolicyNotFound(firewall_policy_id=id)
 
+    @db_api.CONTEXT_READER
     def _get_firewall_rule(self, context, id):
         try:
             return model_query.get_by_id(context, FirewallRuleV2, id)
@@ -612,6 +615,7 @@ class FirewallPluginDb(object):
         policies = self.get_policies_with_rule(context, id) or None
         return self._make_firewall_rule_dict(fwr, fields, policies=policies)
 
+    @db_api.CONTEXT_READER
     def get_firewall_rules(self, context, filters=None, fields=None):
         return model_query.get_collection(
             context, FirewallRuleV2, self._make_firewall_rule_dict,
@@ -654,8 +658,9 @@ class FirewallPluginDb(object):
 
     def _check_rules_for_policy_is_valid(self, context, fwp, fwp_db,
                                          rule_id_list, filters):
-        rules_in_fwr_db = model_query.get_collection_query(
-            context, FirewallRuleV2, filters=filters)
+        with db_api.CONTEXT_READER.using(context):
+            rules_in_fwr_db = model_query.get_collection_query(
+                context, FirewallRuleV2, filters=filters)
         rules_dict = dict((fwr_db['id'], fwr_db) for fwr_db in rules_in_fwr_db)
         for fwrule_id in rule_id_list:
             if fwrule_id not in rules_dict:
@@ -834,6 +839,7 @@ class FirewallPluginDb(object):
         fwp = self._get_firewall_policy(context, id)
         return self._make_firewall_policy_dict(fwp, fields)
 
+    @db_api.CONTEXT_READER
     def get_firewall_policies(self, context, filters=None, fields=None):
         return model_query.get_collection(
             context, FirewallPolicy, self._make_firewall_policy_dict,
@@ -875,6 +881,7 @@ class FirewallPluginDb(object):
                 firewall_group_id=firewall_group_id).delete()
         return
 
+    @db_api.CONTEXT_READER
     def _get_default_fwg_id(self, context, tenant_id):
         """Returns an id of default firewall group for given tenant or None"""
         default_fwg = model_query.query_with_hooks(
@@ -886,9 +893,10 @@ class FirewallPluginDb(object):
 
     def get_fwg_attached_to_port(self, context, port_id):
         """Return a firewall group ID that is attached to a given port"""
-        fwg_port = model_query.query_with_hooks(
-            context, FirewallGroupPortAssociation).\
-            filter_by(port_id=port_id).first()
+        with db_api.CONTEXT_READER.using(context):
+            fwg_port = model_query.query_with_hooks(
+                context, FirewallGroupPortAssociation).\
+                filter_by(port_id=port_id).first()
         if fwg_port:
             return fwg_port.firewall_group_id
         return None
@@ -1110,9 +1118,10 @@ class FirewallPluginDb(object):
             tenant_id = filters.get('tenant_id') if filters else None
             tenant_id = tenant_id[0] if tenant_id else context.tenant_id
             self._ensure_default_firewall_group(context, tenant_id)
-        return model_query.get_collection(
-            context, FirewallGroup, self._make_firewall_group_dict,
-            filters=filters, fields=fields)
+        with db_api.CONTEXT_READER.using(context):
+            return model_query.get_collection(
+                context, FirewallGroup, self._make_firewall_group_dict,
+                filters=filters, fields=fields)
 
 
 def _is_default(fwg_db):


### PR DESCRIPTION
In most cases FirewallPluginDb has opened reader/writer contexts for its db access, but not in all.

For us this failed in one particular case, namely when a router port gets updated and its AFTER_UPDATE methods are called, neutron-fwaas gets a callback for
neutron_fwaas.services.logapi.common.port_callback.NeutronPortCallBack.handle_event, where log_db_api.get_logs_for_port() calls
fw_plugin_db.get_fwg_attached_to_port() - outside of a transaction. This automatically opens a transaction which is never closed, causing a RuntimeError "Must not be called in a transaction" of the dhcp_ready_on_ports() provisioning complete callback.

To avoid this, we add a reader context to get_fwg_attached_to_port() and while we're at it we're adding this to all FirewallPluginDb methods that do a model_query db query - just to be on the safe side.

Change-Id: Iabb9bc6877059bcc46d64b7fc2d0728e6002610b