### PR TITLE
Set service type when registering provider config

### DIFF
--- a/neutron_fwaas/services/firewall/fwaas_plugin_v2.py
+++ b/neutron_fwaas/services/firewall/fwaas_plugin_v2.py
@@ -55,7 +55,8 @@ class FirewallPluginV2(Firewallv2PluginBase):
         service_type_manager = st_db.ServiceTypeManager.get_instance()
         service_type_manager.add_provider_configuration(
             fwaas_constants.FIREWALL_V2,
-            provider_conf.ProviderConfiguration('neutron_fwaas'))
+            provider_conf.ProviderConfiguration('neutron_fwaas',
+                                                fwaas_constants.FIREWALL_V2))
 
         # Load the default driver
         drivers, default_provider = service_base.load_drivers(


### PR DESCRIPTION
When registering the provider configuration with the service type manager we need to specify a service type for ProviderConfiguration(), as described in the Neutron Contributors documentation[0]. If this is not done it might lead to duplicate service providers configuration, as the ProviderConfiguration no longer filters out other services.

[0] https://docs.openstack.org/neutron/latest/contributor/contribute.html#service-providers

Change-Id: I33ba7fdf1748b1604f3ed72a3257d6cf697d6e2b