### PR TITLE
Don't notify/access non-existent ports

### DIFF
--- a/neutron_fwaas/services/logapi/common/fwg_callback.py
+++ b/neutron_fwaas/services/logapi/common/fwg_callback.py
@@ -54,6 +54,8 @@ class FirewallGroupCallBack(manager.ResourceCallBackBase):
         notify = False
         for port_id in ports:
             port = port_objects.Port.get_object(context, id=port_id)
+            if not port:
+                continue
             device_owner = port.get('device_owner', '')
             if device_owner in nl_const.ROUTER_INTERFACE_OWNERS:
                 notify = True

--- a/neutron_fwaas/tests/unit/services/logapi/common/test_fwg_callback.py
+++ b/neutron_fwaas/tests/unit/services/logapi/common/test_fwg_callback.py
@@ -105,6 +105,11 @@ class TestFirewallGroupRuleCallback(base.BaseTestCase):
         result = self.fwg_callback.need_to_notify(self.m_context, [])
         self.assertEqual(False, result)
 
+        # Test with non-existent / vanished port
+        result = self.fwg_callback.need_to_notify(self.m_context,
+                                                  ['non_existent_port'])
+        self.assertEqual(False, result)
+
     def test_trigger_logging(self):
         m_payload = mock.Mock()
         self.fwg_callback.resource_push_api = mock.Mock()


### PR DESCRIPTION
When calling need_to_notify() with a list of port ids where one port does not exist (could have been concurrently deleted) we'll get a None object and with that an AttributeError. To prevent this we skip notification checks for ports which we can't find in the database.

Stacktrace without the fix:

AttributeError: 'NoneType' object has no attribute 'get'
  File "neutron_lib/callbacks/manager.py", line 189, in _notify_loop
    callback.method(resource, event, trigger, payload=payload)
  File "neutron_fwaas/services/logapi/common/fwg_callback.py", line 43, in handle_event
    if self.need_to_notify(context, ports_delta):
  File "neutron_fwaas/services/logapi/common/fwg_callback.py", line 57, in need_to_notify
    device_owner = port.get('device_owner', '')

Change-Id: I56256c776efec21ebb2a212085840bfbd03cfe50